### PR TITLE
Refactor to config-driven runtime

### DIFF
--- a/src/configs/file.py
+++ b/src/configs/file.py
@@ -96,7 +96,7 @@ class FileConfig:
         logger.info("✓ File config validation completed")
 
     def show(self):
-        logger.info(f"TrainConfig: {self.__dict__}")
+        logger.info(f"FileConfig: {self.__dict__}")
 
 
 

--- a/src/configs/model.py
+++ b/src/configs/model.py
@@ -1,3 +1,6 @@
+from loguru import logger
+
+
 class ModelConfig:
     """模型结构与超参数配置。
 
@@ -44,7 +47,7 @@ class ModelConfig:
             self.dim_ffn = int((self.n_embd * 3.5) // 32 * 32)
 
     def show(self):
-        logger.info(f"TrainConfig: {self.__dict__}")
+        logger.info(f"ModelConfig: {self.__dict__}")
 
 
 # 单例实例，供其他模块直接 import 使用

--- a/src/datasets/dataset_pt.py
+++ b/src/datasets/dataset_pt.py
@@ -9,34 +9,24 @@ from torch.utils.data import Dataset
 from torch.utils.data import DataLoader
 from lightning_utilities.core.rank_zero import rank_zero_info
 from .binidx import MMapIndexedDataset
-from src.rwkvt.args_type import TrainingArgs
 from rwkv.utils import PIPELINE
 from src.datasets.SFTdataset import sft_dataset
 
 from .mask import mask_fn_dict
-pipeline = PIPELINE('rwkv6', "rwkv_vocab_v20230424")
+pipeline = PIPELINE('rwkv7', "rwkv_vocab_v20230424")
 
-def get_vocab_size(args: TrainingArgs) -> int:
-    train_data = MyDataset(args)
+from src.configs.train import train_config
+from src.configs.file import file_config
+
+
+def get_vocab_size() -> int:
+    train_data = MyDataset()
     temp = train_data.vocab_size
     del train_data
     return int(temp)
 
-def get_data_by_l_version(trainer: L.Trainer, args: TrainingArgs):
-    if L.__version__[0] == '1':
-        train_data = MyDataset(args)
-        args.vocab_size = train_data.vocab_size
-        train_data.real_epoch = trainer.current_epoch
-        train_data.rank = trainer.global_rank
-        train_data.world_size = trainer.world_size
-        train_data.setup(trainer.global_rank, trainer.world_size, 
-                        int(args.devices), args.data_shuffle)
-        train_data = DataLoader(train_data, shuffle=args.data_shuffle, pin_memory=True, batch_size=args.micro_bsz, num_workers=1, persistent_workers=False, drop_last=True)
-    
-    elif L.__version__[0] == '2':
-        train_data = MyDataModule(args)
-    else:
-        raise ValueError(f"Unsupported PyTorch Lightning version: {L.__version__}")
+def get_data(trainer: L.Trainer):
+    train_data = MyDataModule()
     return train_data
 
 class GlobalIndexManager:
@@ -55,49 +45,49 @@ class GlobalIndexManager:
         return idx
 
 class MyDataModule(L.LightningDataModule):
-    def __init__(self, args: TrainingArgs):
+    def __init__(self):
         super().__init__()
-        self.args = args
+        self.args = train_config
         self.train_data = None
         
     def setup(self, stage=None):
-        self.train_data = MyDataset(self.args)
-        self.args.vocab_size = self.train_data.vocab_size
+        self.train_data = MyDataset()
+        train_config.vocab_size = self.train_data.vocab_size
         self.train_data.real_epoch = self.trainer.current_epoch
         self.train_data.rank = self.trainer.global_rank
         self.train_data.world_size = self.trainer.world_size
-        self.train_data.setup(self.trainer.global_rank, self.trainer.world_size, 
-                              int(self.args.devices), self.args.data_shuffle)
+        self.train_data.setup(self.trainer.global_rank, self.trainer.world_size,
+                              int(train_config.devices), train_config.data_shuffle)
         
     def train_dataloader(self):
         # must set shuffle=False, persistent_workers=False (because worker is in another thread)
         return DataLoader(
             self.train_data,
-            shuffle=self.args.data_shuffle,
+            shuffle=train_config.data_shuffle,
             pin_memory=True,
-            batch_size=self.args.micro_bsz,
+            batch_size=train_config.micro_bsz,
             num_workers=1,
             persistent_workers=False,
             drop_last=True
         )
 
 class MyDataset(Dataset):
-    def __init__(self, args: TrainingArgs):
-        self.args = args
+    def __init__(self):
+        self.args = train_config
         self.rank = 0
         self.real_epoch = 0
         self.world_size = 0
         self.index_manager = None
-        self.vocab_size = args.vocab_size
-        if args.data_type == "sft":
-            self.data = sft_dataset(args)
-        elif args.data_type == "jsonl":
+        self.vocab_size = train_config.vocab_size
+        if train_config.data_type == "sft":
+            self.data = sft_dataset(train_config)
+        elif train_config.data_type == "jsonl":
             import jsonlines
-            with jsonlines.open(args.data_file) as file:
+            with jsonlines.open(file_config.data_file) as file:
                 self.data = list(file)
 
-        elif args.data_type == "binidx":
-            self.data = MMapIndexedDataset(args.data_file)
+        elif train_config.data_type == "binidx":
+            self.data = MMapIndexedDataset(file_config.data_file)
             self.data_size = len(self.data._bin_buffer) // self.data._index._dtype_size
             rank_zero_info(f"Data has {self.data_size} tokens.")
 
@@ -109,24 +99,24 @@ class MyDataset(Dataset):
         self.index_manager = GlobalIndexManager(rank=rank, device_num=devices, shuffle=shuffle)
     
     def __len__(self):
-        return self.args.epoch_steps * self.args.micro_bsz
+        return train_config.epoch_steps * train_config.micro_bsz
 
     def __getitem__(self, idx):
         idx = self.index_manager.get_next_idx(idx_t=idx) if self.index_manager else idx
-        args = self.args
+        args = train_config
         rank = self.rank
         epoch = self.real_epoch
         world_size = self.world_size
 
 
-        if args.data_type == "sft":
+        if train_config.data_type == "sft":
 
             inputs, labels, attn_mask = self.data[0][idx], self.data[1][idx], self.data[2][idx]
             labels= torch.roll(labels, shifts=-1, dims=-1)
 
             return inputs, labels, attn_mask
-        elif args.data_type == "jsonl":
-            ctx_len = args.ctx_len
+        elif train_config.data_type == "jsonl":
+            ctx_len = train_config.ctx_len
             req_len = ctx_len + 1
             ctx = self.data[idx]['text']
             token = torch.tensor(pipeline.encode(ctx))
@@ -145,22 +135,22 @@ class MyDataset(Dataset):
             y = label[1:]
 
         else:
-            ctx_len = args.ctx_len
+            ctx_len = train_config.ctx_len
             req_len = ctx_len + 1
             data = self.data
 
 
-            if args.data_type == "binidx":
-                if args.dataload == 'pad':
+            if train_config.data_type == "binidx":
+                if train_config.dataload == 'pad':
                     dix, min_len = data.pad(idx=idx, length=req_len)
-                elif args.dataload == 'only':
+                elif train_config.dataload == 'only':
                     dix = data.only(idx=idx, length=req_len).astype(int)
 
             x = torch.tensor(dix[:-1], dtype=torch.long)
             dix[min_len:] = -100
             y = torch.tensor(dix[1:], dtype=torch.long)
 
-        mask_fn = mask_fn_dict.get(args.loss_mask)
+        mask_fn = mask_fn_dict.get(train_config.loss_mask)
 
         if mask_fn!=None:
             t1 = pipeline.encode('User:')

--- a/src/model/operator/rwkvop.py
+++ b/src/model/operator/rwkvop.py
@@ -1,6 +1,8 @@
 
 from einops import rearrange
-import os, math, gc, importlib
+import math, gc, importlib
+from src.configs.model import model_config
+from src.configs.train import train_config
 import torch
 ########################################################################################################
 # CUDA Kernel
@@ -14,21 +16,11 @@ def RUN_RWKV7_STATE():
 def RUN_RWKV7_INFCTX():
     raise NotImplementedError('RUN_CUDA_RUN_KV not implemented')
 
-def RUN_CUDA_RWKV6():
-    raise NotImplementedError('RUN_CUDA_RUN_KV not implemented')
 
-
-def RUN_CUDA_RWKV6_STATE():
-    raise NotImplementedError('RUN_CUDA_RUN_KV not implemented')
-
-
-def RUN_CUDA_RWKV5():
-    raise NotImplementedError('RUN_CUDA_RUN_KV not implemented')
-
-if os.environ["WKV"] == 'fla':
-    if 'x070' in os.environ["RWKV_MY_TESTING"]:
+if model_config.op == 'fla':
+    if '7' in train_config.my_testing:
         from rwkvfla.ops.rwkv7 import chunk_rwkv7
-        if os.environ["RWKV_TRAIN_TYPE"] == 'infctx':
+        if train_config.train_type == 'infctx':
             def RUN_RWKV7_INFCTX(r, k, v, w, a, b, s, HEAD_SIZE=64): # for State-tuning, infctx
                 B,T,HC = w.shape
                 C = HEAD_SIZE
@@ -37,7 +29,7 @@ if os.environ["WKV"] == 'fla':
                 # when use w=, -exp(w) is not needed, w=-torch.exp(w), otherwise, use log_w = -torch.exp(w)
                 o, state = chunk_rwkv7(r=r, w=w, k=k, v=v, a=a, b=b, scale=1.0, initial_state=s, output_final_state=True, head_first=False)
                 return o, state
-        if os.environ["RWKV_TRAIN_TYPE"] == 'state':
+        if train_config.train_type == 'state':
             def RUN_RWKV7_STATE(r, k, v, w, a, b, s, HEAD_SIZE=64): # for State-tuning, infctx
                 B,T,HC = w.shape
                 C = HEAD_SIZE
@@ -56,38 +48,7 @@ if os.environ["WKV"] == 'fla':
                 # when use w=, -exp(w) is not needed, w=-torch.exp(w), otherwise, use log_w = -torch.exp(w)
                 o, _ = chunk_rwkv7(r=r, w=w, k=k, v=v, a=a, b=b, scale=1.0, initial_state=None, output_final_state=False, head_first=False)
                 return o
-    if 'x060' in os.environ["RWKV_MY_TESTING"]:
-        from rwkvfla.ops.rwkv6 import chunk_rwkv6
-
-        if os.environ["RWKV_TRAIN_TYPE"] == 'infctx':
-            def RUN_CUDA_RWKV6_STATE(B, T, C, H, r, k, v, w, u, s):
-                r = rearrange(r, 'b l (h d) -> b h l d', h = H)
-                k = rearrange(k, 'b l (h d) -> b h l d', h = H)
-                v = rearrange(v, 'b l (h d) -> b h l d', h = H)
-                w = rearrange(-torch.exp(w), 'b l (h d) -> b h l d', h = H)
-                o, state = chunk_rwkv6(r, k, v, w, u=u, scale=1., initial_state=s, output_final_state=True)
-                x = rearrange(o, 'b h l d -> b l (h d)')
-                return x, state
-        elif os.environ["RWKV_TRAIN_TYPE"] == 'state':
-            def RUN_CUDA_RWKV6_STATE(B, T, C, H, r, k, v, w, u, s):
-                r = rearrange(r, 'b l (h d) -> b h l d', h = H)
-                k = rearrange(k, 'b l (h d) -> b h l d', h = H)
-                v = rearrange(v, 'b l (h d) -> b h l d', h = H)
-                w = rearrange(-torch.exp(w), 'b l (h d) -> b h l d', h = H)
-                s = s.transpose(1, 2).expand(B,*s.shape)
-                o,_ = chunk_rwkv6(r, k, v, w, u=u, scale=1., initial_state=s, output_final_state=False)
-                x = rearrange(o, 'b h l d -> b l (h d)')
-                return x
-        else:
-            def RUN_CUDA_RWKV6(B, T, C, H, r, k, v, w, u):
-                r = rearrange(r, 'b l (h d) -> b h l d', h = H)
-                k = rearrange(k, 'b l (h d) -> b h l d', h = H)
-                v = rearrange(v, 'b l (h d) -> b h l d', h = H)
-                w = rearrange(-torch.exp(w), 'b l (h d) -> b h l d', h = H)
-                o,_ = chunk_rwkv6(r, k, v, w, u=u, scale=1., initial_state=None, output_final_state=False)
-                x = rearrange(o, 'b h l d -> b l (h d)')
-                return x
-elif os.environ["WKV"] == 'triton':
+elif model_config.op == 'triton':
     print('x070 Wind Triton Kernel Mode')
 
     import torch as th
@@ -296,8 +257,8 @@ elif os.environ["WKV"] == 'triton':
 else:
     from torch.utils.cpp_extension import load
 
-    HEAD_SIZE = int(os.environ["RWKV_HEAD_SIZE_A"])
-    if 'x070' in os.environ["RWKV_MY_TESTING"]:
+    HEAD_SIZE = int(model_config.head_size_a)
+    if '7' in train_config.my_testing:
         CHUNK_LEN = 16
 
         flags = ['-res-usage', f'-D_C_={HEAD_SIZE}', f"-D_CHUNK_LEN_={CHUNK_LEN}", "--use_fast_math", "-O3", "-Xptxas -O3", "--extra-device-vectorization"]
@@ -330,217 +291,6 @@ else:
             q,w,k,v,a,b = [i.view(B,T,HC//64,64) for i in [q,w,k,v,a,b]]
             return WindBackstepping.apply(w,q,k,v,a,b).view(B,T,HC)
 
-    elif 'x060' in os.environ["RWKV_MY_TESTING"]:
-        if os.environ["RWKV_TRAIN_TYPE"] == 'infctx':
-            wkv6state_cuda = load(name="wkv6infctx", sources=["cuda/wkv6infctx_op.cpp", f"cuda/wkv6infctx_cuda.cu"],
-                            verbose=True, extra_cuda_cflags=["-res-usage", "--use_fast_math", "-O3", "-Xptxas -O3", "--extra-device-vectorization", f"-D_N_={HEAD_SIZE}", f"-D_T_={int(os.environ['RWKV_CTXLEN'])}"])
-                
-            class WKV_6STATE(torch.autograd.Function):
-                @staticmethod
-                def forward(ctx, B, T, C, H, r, k, v, w, u, s):
-                    with torch.no_grad():
-                        assert r.dtype == torch.bfloat16
-                        assert k.dtype == torch.bfloat16
-                        assert v.dtype == torch.bfloat16
-                        assert w.dtype == torch.bfloat16
-                        assert u.dtype == torch.bfloat16
-                        assert s.dtype == torch.bfloat16
-                        assert HEAD_SIZE == C // H
-                        ctx.B = B
-                        ctx.T = T
-                        ctx.C = C
-                        ctx.H = H
-                        assert r.is_contiguous()
-                        assert k.is_contiguous()
-                        assert v.is_contiguous()
-                        assert w.is_contiguous()
-                        assert u.is_contiguous()
-                        assert s.is_contiguous()
-                        ctx.save_for_backward(r, k, v, w, u, s)
-                        y = torch.empty((B, T, C), device=r.device, dtype=torch.bfloat16, memory_format=torch.contiguous_format)#.uniform_(-100, 100)
-                        wkv6state_cuda.forward(B, T, C, H, r, k, v, w, u, s, y)
-                        return y
-
-                @staticmethod
-                def backward(ctx, gy):
-                    with torch.no_grad():
-                        assert gy.dtype == torch.bfloat16
-                        B = ctx.B
-                        T = ctx.T
-                        C = ctx.C
-                        H = ctx.H
-                        assert gy.is_contiguous()
-                        r, k, v, w, u, s = ctx.saved_tensors
-                        gr = torch.empty((B, T, C), device=gy.device, requires_grad=False, dtype=torch.bfloat16, memory_format=torch.contiguous_format)#.uniform_(-100, 100)
-                        gk = torch.empty((B, T, C), device=gy.device, requires_grad=False, dtype=torch.bfloat16, memory_format=torch.contiguous_format)#.uniform_(-100, 100)
-                        gv = torch.empty((B, T, C), device=gy.device, requires_grad=False, dtype=torch.bfloat16, memory_format=torch.contiguous_format)#.uniform_(-100, 100)
-                        gw = torch.empty((B, T, C), device=gy.device, requires_grad=False, dtype=torch.bfloat16, memory_format=torch.contiguous_format)#.uniform_(-100, 100)
-                        gu = torch.empty((B, C), device=gy.device, requires_grad=False, dtype=torch.bfloat16, memory_format=torch.contiguous_format)#.uniform_(-100, 100)
-                        gs = torch.empty((B, H, C//H, C//H), device=gy.device, requires_grad=False, dtype=torch.bfloat16, memory_format=torch.contiguous_format)#.uniform_(-100, 100)
-                        wkv6state_cuda.backward(B, T, C, H, r, k, v, w, u, s, gy, gr, gk, gv, gw, gu, gs)
-                        gu = torch.sum(gu, 0).view(H, C//H)
-                        gs = torch.sum(gs, 0).view(H, C//H, C//H)
-                        return (None, None, None, None, gr, gk, gv, gw, gu, gs)
-
-            def RUN_CUDA_RWKV6_STATE(B, T, C, H, r, k, v, w, u, s):
-                x = WKV_6STATE.apply(B, T, C, H, r, k, v, w, u, s)
-                return x, s
-        elif os.environ["RWKV_TRAIN_TYPE"] == 'state':
-            wkv6state_cuda = load(name="wkv6state", sources=["cuda/wkv6state_op.cpp", f"cuda/wkv6state_cuda.cu"],
-                            verbose=True, extra_cuda_cflags=["-res-usage", "--use_fast_math", "-O3", "-Xptxas -O3", "--extra-device-vectorization", f"-D_N_={HEAD_SIZE}", f"-D_T_={int(os.environ['RWKV_CTXLEN'])}"])
-                
-            class WKV_6STATE(torch.autograd.Function):
-                @staticmethod
-                def forward(ctx, B, T, C, H, r, k, v, w, u, s):
-                    with torch.no_grad():
-                        assert r.dtype == torch.bfloat16
-                        assert k.dtype == torch.bfloat16
-                        assert v.dtype == torch.bfloat16
-                        assert w.dtype == torch.bfloat16
-                        assert u.dtype == torch.bfloat16
-                        assert s.dtype == torch.bfloat16
-                        assert HEAD_SIZE == C // H
-                        ctx.B = B
-                        ctx.T = T
-                        ctx.C = C
-                        ctx.H = H
-                        assert r.is_contiguous()
-                        assert k.is_contiguous()
-                        assert v.is_contiguous()
-                        assert w.is_contiguous()
-                        assert u.is_contiguous()
-                        assert s.is_contiguous()
-                        ctx.save_for_backward(r, k, v, w, u, s)
-                        y = torch.empty((B, T, C), device=r.device, dtype=torch.bfloat16, memory_format=torch.contiguous_format)#.uniform_(-100, 100)
-                        wkv6state_cuda.forward(B, T, C, H, r, k, v, w, u, s, y)
-                        return y
-
-                @staticmethod
-                def backward(ctx, gy):
-                    with torch.no_grad():
-                        assert gy.dtype == torch.bfloat16
-                        B = ctx.B
-                        T = ctx.T
-                        C = ctx.C
-                        H = ctx.H
-                        assert gy.is_contiguous()
-                        r, k, v, w, u, s = ctx.saved_tensors
-                        gr = torch.empty((B, T, C), device=gy.device, requires_grad=False, dtype=torch.bfloat16, memory_format=torch.contiguous_format)#.uniform_(-100, 100)
-                        gk = torch.empty((B, T, C), device=gy.device, requires_grad=False, dtype=torch.bfloat16, memory_format=torch.contiguous_format)#.uniform_(-100, 100)
-                        gv = torch.empty((B, T, C), device=gy.device, requires_grad=False, dtype=torch.bfloat16, memory_format=torch.contiguous_format)#.uniform_(-100, 100)
-                        gw = torch.empty((B, T, C), device=gy.device, requires_grad=False, dtype=torch.bfloat16, memory_format=torch.contiguous_format)#.uniform_(-100, 100)
-                        gu = torch.empty((B, C), device=gy.device, requires_grad=False, dtype=torch.bfloat16, memory_format=torch.contiguous_format)#.uniform_(-100, 100)
-                        gs = torch.empty((B, H, C//H, C//H), device=gy.device, requires_grad=False, dtype=torch.bfloat16, memory_format=torch.contiguous_format)#.uniform_(-100, 100)
-                        wkv6state_cuda.backward(B, T, C, H, r, k, v, w, u, s, gy, gr, gk, gv, gw, gu, gs)
-                        gu = torch.sum(gu, 0).view(H, C//H)
-                        gs = torch.sum(gs, 0).view(H, C//H, C//H)
-                        return (None, None, None, None, gr, gk, gv, gw, gu, gs)
-
-            def RUN_CUDA_RWKV6_STATE(B, T, C, H, r, k, v, w, u, s):
-                return WKV_6STATE.apply(B, T, C, H, r, k, v, w, u, s)
-
-        else:
-            wkv6_cuda = load(name="wkv6", sources=["cuda/wkv6_op.cpp", f"cuda/wkv6_cuda.cu"],
-                            verbose=True, extra_cuda_cflags=["-res-usage", "--use_fast_math", "-O3", "-Xptxas -O3", "--extra-device-vectorization", f"-D_N_={HEAD_SIZE}", f"-D_T_={int(os.environ['RWKV_CTXLEN'])}"])
-                
-            class WKV_6(torch.autograd.Function):
-                @staticmethod
-                def forward(ctx, B, T, C, H, r, k, v, w, u):
-                    with torch.no_grad():
-                        assert r.dtype == torch.bfloat16
-                        assert k.dtype == torch.bfloat16
-                        assert v.dtype == torch.bfloat16
-                        assert w.dtype == torch.bfloat16
-                        assert u.dtype == torch.bfloat16
-                        assert HEAD_SIZE == C // H
-                        ctx.B = B
-                        ctx.T = T
-                        ctx.C = C
-                        ctx.H = H
-                        assert r.is_contiguous()
-                        assert k.is_contiguous()
-                        assert v.is_contiguous()
-                        assert w.is_contiguous()
-                        assert u.is_contiguous()
-                        ew = (-torch.exp(w.float())).contiguous()
-                        ctx.save_for_backward(r, k, v, ew, u)
-                        y = torch.empty((B, T, C), device=r.device, dtype=torch.bfloat16, memory_format=torch.contiguous_format)#.uniform_(-100, 100)
-                        wkv6_cuda.forward(B, T, C, H, r, k, v, ew, u, y)
-                        return y
-
-                @staticmethod
-                def backward(ctx, gy):
-                    with torch.no_grad():
-                        assert gy.dtype == torch.bfloat16
-                        B = ctx.B
-                        T = ctx.T
-                        C = ctx.C
-                        H = ctx.H
-                        assert gy.is_contiguous()
-                        r, k, v, ew, u = ctx.saved_tensors
-                        gr = torch.empty((B, T, C), device=gy.device, requires_grad=False, dtype=torch.bfloat16, memory_format=torch.contiguous_format)#.uniform_(-100, 100)
-                        gk = torch.empty((B, T, C), device=gy.device, requires_grad=False, dtype=torch.bfloat16, memory_format=torch.contiguous_format)#.uniform_(-100, 100)
-                        gv = torch.empty((B, T, C), device=gy.device, requires_grad=False, dtype=torch.bfloat16, memory_format=torch.contiguous_format)#.uniform_(-100, 100)
-                        gw = torch.empty((B, T, C), device=gy.device, requires_grad=False, dtype=torch.bfloat16, memory_format=torch.contiguous_format)#.uniform_(-100, 100)
-                        gu = torch.empty((B, C), device=gy.device, requires_grad=False, dtype=torch.bfloat16, memory_format=torch.contiguous_format)#.uniform_(-100, 100)
-                        wkv6_cuda.backward(B, T, C, H, r, k, v, ew, u, gy, gr, gk, gv, gw, gu)
-                        gu = torch.sum(gu, 0).view(H, C//H)
-                        return (None, None, None, None, gr, gk, gv, gw, gu)
-
-            def RUN_CUDA_RWKV6(B, T, C, H, r, k, v, w, u):
-                return WKV_6.apply(B, T, C, H, r, k, v, w, u)
-    else:
-        wkv5_cuda = load(name="wkv5", sources=["cuda/wkv5_op.cpp", f"cuda/wkv5_cuda.cu"],
-                        verbose=True, extra_cuda_cflags=["-res-usage", "--use_fast_math", "-O3", "-Xptxas -O3", "--extra-device-vectorization", f"-D_N_={HEAD_SIZE}"])
-            
-        class WKV_5(torch.autograd.Function):
-            @staticmethod
-            def forward(ctx, B, T, C, H, r, k, v, w, u):
-                with torch.no_grad():
-                    assert r.dtype == torch.bfloat16
-                    assert k.dtype == torch.bfloat16
-                    assert v.dtype == torch.bfloat16
-                    assert w.dtype == torch.bfloat16
-                    assert u.dtype == torch.bfloat16
-                    assert HEAD_SIZE == C // H
-                    ctx.B = B
-                    ctx.T = T
-                    ctx.C = C
-                    ctx.H = H
-                    assert r.is_contiguous()
-                    assert k.is_contiguous()
-                    assert v.is_contiguous()
-                    assert w.is_contiguous()
-                    assert u.is_contiguous()
-                    ew = (-torch.exp(w.float())).contiguous()
-                    eew = (torch.exp(ew)).contiguous()
-                    ctx.save_for_backward(r, k, v, eew, ew, u)
-                    y = torch.empty((B, T, C), device=r.device, dtype=torch.bfloat16, memory_format=torch.contiguous_format) # .uniform_(-1, 1)
-                    wkv5_cuda.forward(B, T, C, H, r, k, v, eew, u, y)
-                    return y
-
-            @staticmethod
-            def backward(ctx, gy):
-                with torch.no_grad():
-                    assert gy.dtype == torch.bfloat16
-                    B = ctx.B
-                    T = ctx.T
-                    C = ctx.C
-                    H = ctx.H
-                    assert gy.is_contiguous()
-                    r, k, v, eew, ew, u = ctx.saved_tensors
-                    gr = torch.empty((B, T, C), device=gy.device, requires_grad=False, dtype=torch.bfloat16, memory_format=torch.contiguous_format) # .uniform_(-1, 1)
-                    gk = torch.empty((B, T, C), device=gy.device, requires_grad=False, dtype=torch.bfloat16, memory_format=torch.contiguous_format) # .uniform_(-1, 1)
-                    gv = torch.empty((B, T, C), device=gy.device, requires_grad=False, dtype=torch.bfloat16, memory_format=torch.contiguous_format) # .uniform_(-1, 1)
-                    gw = torch.empty((B, C), device=gy.device, requires_grad=False, dtype=torch.bfloat16, memory_format=torch.contiguous_format) # .uniform_(-1, 1)
-                    gu = torch.empty((B, C), device=gy.device, requires_grad=False, dtype=torch.bfloat16, memory_format=torch.contiguous_format) # .uniform_(-1, 1)
-                    wkv5_cuda.backward(B, T, C, H, r, k, v, eew, ew, u, gy, gr, gk, gv, gw, gu)
-                    gw = torch.sum(gw, 0).view(H, C//H)
-                    gu = torch.sum(gu, 0).view(H, C//H)
-                    return (None, None, None, None, gr, gk, gv, gw, gu)
-
-        def RUN_CUDA_RWKV5(B, T, C, H, r, k, v, w, u):
-            return WKV_5.apply(B, T, C, H, r, k, v, w, u)
 
 ########################################################################################################
 

--- a/src/model/rwkv7/att.py
+++ b/src/model/rwkv7/att.py
@@ -1,5 +1,5 @@
 
-import os, math
+import math
 
 import torch.nn as nn
 from src.rwkvt.infctx_module import *
@@ -8,7 +8,10 @@ from src.rwkvt.peft.rwkvLinear import make_linear_att
 from src.model.operator.rwkvop import RUN_CUDA_RWKV7g, RUN_RWKV7_STATE, RUN_RWKV7_INFCTX
 from torch.nn import functional as F
 
-if os.environ["FUSED_KERNEL"] == '1':
+from src.configs.model import model_config
+from src.configs.train import train_config
+
+if model_config.fused_kernel:
     from rwkvfla.ops.rwkv7 import fused_addcmul_rwkv7
     from rwkvfla.modules.layernorm import GroupNorm as FusedGroupNorm
 else:
@@ -16,10 +19,9 @@ else:
     FusedGroupNorm = None
 
 def RWKV_Tmix_v7(*args, **kwargs):
-    
-    if os.environ["RWKV_TRAIN_TYPE"] == 'state':
+    if train_config.train_type == 'state':
         return RWKV_Tmix_x070_State(*args, **kwargs)
-    elif os.environ["RWKV_TRAIN_TYPE"] == 'infctx':
+    elif train_config.train_type == 'infctx':
         return RWKV_Tmix_x070_infctx(*args, **kwargs)
     else:
         return RWKV_Tmix_x070(*args, **kwargs)
@@ -38,7 +40,7 @@ class RWKV_Tmix_x070(nn.Module):
         N = self.head_size
         C = args.n_embd
 
-        if os.environ["FUSED_KERNEL"] == '1':
+        if model_config.fused_kernel:
             self.addcmul_kernel = self.fused_addcmul
         else:
             self.addcmul_kernel = self.torch_addcmul
@@ -110,7 +112,7 @@ class RWKV_Tmix_x070(nn.Module):
             self.key = make_linear_att(C, C, bias=False)
             self.value = make_linear_att(C, C, bias=False)
             self.output = make_linear_att(C, C, bias=False)
-            if os.environ["FUSED_KERNEL"] == '1':
+            if model_config.fused_kernel:
                 self.ln_x = FusedGroupNorm(H, C, eps=(1e-5)*(args.head_size_divisor**2), bias=True) # !!! notice eps value !!!
             else:
                 self.ln_x = nn.GroupNorm(H, C, eps=(1e-5)*(args.head_size_divisor**2))

--- a/src/model/rwkv7/block.py
+++ b/src/model/rwkv7/block.py
@@ -31,7 +31,8 @@ class Block(nn.Module):
     @property
     def _use_infctx(self):
         """判断是否使用无限上下文模式"""
-        return os.environ.get("RWKV_TRAIN_TYPE") == 'infctx'
+        from src.configs.train import train_config
+        return train_config.train_type == 'infctx'
 
     def forward(self, *args, **kwargs):
         if self._use_infctx:

--- a/src/model/rwkv7/ffn.py
+++ b/src/model/rwkv7/ffn.py
@@ -1,18 +1,19 @@
-import os
 import torch.nn as nn
 from src.rwkvt.infctx_module import *
 from src.rwkvt.peft.rwkvLinear import make_linear_ffn
+from src.configs.model import model_config
+from src.configs.train import train_config
 
-if os.environ["FUSED_KERNEL"] == '1':
+if model_config.fused_kernel:
     from rwkvfla.ops.rwkv7 import channel_mixing_rwkv7
 else:
     channel_mixing_rwkv7 = None
 
 def RWKV_Cmix_v7(*args, **kwargs):
-    
-    if os.environ["RWKV_TRAIN_TYPE"] == 'infctx':
+
+    if train_config.train_type == 'infctx':
         return RWKV_CMix_x070_infctx(*args, **kwargs)
-    elif os.environ["FUSED_KERNEL"] == '1':
+    elif model_config.fused_kernel:
         return RWKV_CMix_x070_fla(*args, **kwargs)
     else:
         return RWKV_CMix_x070(*args, **kwargs)

--- a/src/model/rwkv7/model.py
+++ b/src/model/rwkv7/model.py
@@ -24,7 +24,8 @@ class RWKV7(nn.Module):
     @property
     def _use_infctx(self):
         """判断是否使用无限上下文模式"""
-        return os.environ.get("RWKV_TRAIN_TYPE") == 'infctx'
+        from src.configs.train import train_config
+        return train_config.train_type == 'infctx'
 
     def forward(self, *args, **kwargs):
         if self._use_infctx:

--- a/src/rwkvt/lightning_train/light_rwkv.py
+++ b/src/rwkvt/lightning_train/light_rwkv.py
@@ -6,6 +6,8 @@ from torch.utils.checkpoint import checkpoint as torch_checkpoint
 
 import os, math, gc, importlib
 import torch
+from src.configs.train import train_config
+from src.configs.model import model_config
 # torch._C._jit_set_profiling_executor(True)
 # torch._C._jit_set_profiling_mode(True)
 import torch.nn as nn
@@ -16,23 +18,12 @@ if importlib.util.find_spec('deepspeed'):
 from src.rwkvt.infctx_module import BlockStateList
 
 
-try:
-    print('RWKV_MY_TESTING', os.environ["RWKV_MY_TESTING"])
-except:
-    os.environ["RWKV_MY_TESTING"] = ''
+print('RWKV_MY_TESTING', train_config.my_testing)
 
 
+from src.model.rwkv7.model import RWKV7 as RWKVModel
 
-if "7" in os.environ["RWKV_MY_TESTING"]:
-    from src.model.rwkv7.model import RWKV7 as RWKVModel
-elif "6" in os.environ["RWKV_MY_TESTING"]:
-    from src.rwkvt.rwkv6.model import RWKV6 as RWKVModel
-elif "5" in os.environ["RWKV_MY_TESTING"]:
-    from src.rwkvt.rwkv5.model import RWKV5 as RWKVModel
-else:
-    raise ValueError(f"Unsupported model version: . Valid options: 5,6,7")
-
-if os.environ["RWKV_TRAIN_TYPE"] == 'infctx':
+if train_config.train_type == 'infctx':
     class L2Wrap(torch.autograd.Function):
         @staticmethod
         def forward(ctx, loss, y, token_amount):
@@ -78,7 +69,7 @@ class RWKV(pl.LightningModule):
         super().__init__()
         self.args = args
         self.model = RWKVModel(args)
-        if os.environ["FUSED_KERNEL"] == '1':
+        if model_config.fused_kernel:
             from rwkvfla.modules import FusedCrossEntropyLoss
             self.criterion = FusedCrossEntropyLoss(inplace_backward=True)
         else:
@@ -165,7 +156,7 @@ class RWKV(pl.LightningModule):
             return cfg.get("offload_optimizer") or cfg.get("offload_param")
         return False
 
-    if os.environ.get("RWKV_TRAIN_TYPE") == 'infctx':
+    if train_config.train_type == 'infctx':
         def forward(self, idx,  last_shift_states: torch.Tensor,
                 last_wkv_states: torch.Tensor, attention_mask=None):
             return self.model(idx, last_shift_states, last_wkv_states, attention_mask)
@@ -173,7 +164,7 @@ class RWKV(pl.LightningModule):
         def forward(self, idx, attention_mask=None):
             return self.model(idx, attention_mask)
 
-    if os.environ.get("RWKV_TRAIN_TYPE") == 'infctx':
+    if train_config.train_type == 'infctx':
         def training_step(self, batch, batch_idx):
             args = self.args
             T_train = args.chunk_ctx 
@@ -239,10 +230,7 @@ class RWKV(pl.LightningModule):
     
     
     def training_step_end(self, batch_parts):
-        if pl.__version__[0]!='2':
-            all = self.all_gather(batch_parts)
-            if self.trainer.is_global_zero:
-                self.trainer.my_loss_all = all
+        pass
 
     def generate_init_weight(self):
         print(
@@ -301,9 +289,9 @@ class RWKV(pl.LightningModule):
                     nn.init.orthogonal_(m[n], gain=gain * scale)
 
             m[n] = m[n].cpu()
-            if os.environ["RWKV_FLOAT_MODE"] == "fp16":
+            if train_config.precision == "fp16":
                 m[n] = m[n].half()
-            elif os.environ["RWKV_FLOAT_MODE"] == "bf16":
+            elif train_config.precision == "bf16":
                 m[n] = m[n].bfloat16()
 
             # if n == "emb.weight":

--- a/src/rwkvt/lightning_train/trainer.py
+++ b/src/rwkvt/lightning_train/trainer.py
@@ -100,10 +100,9 @@ class train_callback(pl.Callback):
         token_per_step = args.ctx_len * args.real_bsz
         real_step = trainer.global_step + args.epoch_begin * args.epoch_steps
 
-        if pl.__version__[0]=='2' :
-            loss = outputs['loss']
-            if int(args.devices)>1:
-                torch.distributed.all_reduce(loss, op=torch.distributed.ReduceOp.SUM)
+        loss = outputs['loss']
+        if int(args.devices)>1:
+            torch.distributed.all_reduce(loss, op=torch.distributed.ReduceOp.SUM)
 
         if trainer.is_global_zero:  # logging
             t_now = time.time_ns()
@@ -118,10 +117,7 @@ class train_callback(pl.Callback):
             except:
                 pass
             trainer.my_time_ns = t_now
-            if pl.__version__[0]=='2':
-                trainer.my_loss = loss*trainer.accumulate_grad_batches/int(args.devices)
-            else:
-                trainer.my_loss = trainer.my_loss_all.float().mean().item()
+            trainer.my_loss = loss*trainer.accumulate_grad_batches/int(args.devices)
             trainer.my_loss_sum += trainer.my_loss
             trainer.my_loss_count += 1
             trainer.my_epoch_loss = trainer.my_loss_sum / trainer.my_loss_count
@@ -151,10 +147,7 @@ class train_callback(pl.Callback):
 
     def on_train_epoch_start(self, trainer, pl_module):
         args = self.args
-        if pl.__version__[0]=='2':
-            dataset = trainer.train_dataloader.dataset
-        else:
-            dataset = trainer.train_dataloader.dataset.datasets
+        dataset = trainer.train_dataloader.dataset
         assert "MyDataset" in str(dataset)
         dataset.global_rank = trainer.global_rank
         dataset.real_epoch = int(args.epoch_begin + trainer.current_epoch)

--- a/src/rwkvt/peft/peft_loading.py
+++ b/src/rwkvt/peft/peft_loading.py
@@ -1,12 +1,15 @@
 import os
 import torch
 from src.rwkvt.lightning_train.light_rwkv import RWKV
-from src.rwkvt.args_type import TrainingArgs
 from lightning_utilities.core.rank_zero import rank_zero_info
 from src.rwkvt.lightning_train.trainer import generate_init_weight
 from src.rwkvt.peft.rwkvLinear import LORA_CONFIG
+from src.configs.train import train_config
+from src.configs.file import file_config
+from src.configs.model import model_config
 
-def load_peft_model(args: TrainingArgs):
+def load_peft_model():
+    args = train_config
     freeze = False
     if args.peft == 'lora':
         assert args.lora_config['lora_r'] > 0, "LoRA should have its `r` > 0"
@@ -28,7 +31,7 @@ def load_peft_model(args: TrainingArgs):
     model = RWKV(args)
     print(model)
 
-    if os.environ["RWKV_TRAIN_TYPE"] == 'state':
+    if args.train_type == 'state':
         model.requires_grad_(False)
         freeze = True
         for name, module in model.named_modules():

--- a/src/utils/datasets.py
+++ b/src/utils/datasets.py
@@ -60,7 +60,8 @@ class TOKENIZER():
         else:
             top_p = top_p_usual
 
-        if os.environ["RWKV_RUN_DEVICE"] == "cpu":
+        from src.configs.model import model_config
+        if model_config.op == "cpu":
             probs = probs.numpy()
             sorted_probs = np.sort(probs)[::-1]
             cumulative_probs = np.cumsum(sorted_probs)

--- a/train.py
+++ b/train.py
@@ -1,329 +1,54 @@
-########################################################################################################
-# The RWKV Language Model - https://github.com/BlinkDL/RWKV-LM
-########################################################################################################
-# logging.basicConfig(level=logging.INFO)
+import warnings
+import datetime
+import numpy as np
+import torch
+import lightning as pl
+from lightning import Trainer
+from src.configs.file import file_config
+from src.configs.model import model_config
+from src.configs.train import train_config
+from src.rwkvt.peft.peft_loading import load_peft_model
+from src.rwkvt.lightning_train.trainer import train_callback
+from src.datasets.dataset_pt import get_data
 
-if __name__ == "__main__":
-    from argparse import ArgumentParser
-    from lightning import Trainer
-    from lightning.pytorch import seed_everything
-    from lightning_utilities.core.rank_zero import rank_zero_info
-    import lightning as pl
-    import json
-    from src.rwkvt import get_data_by_l_version
-
-    rank_zero_info("########## work in progress ##########")
-
-    parser = ArgumentParser()
-
-    parser.add_argument("--load_model", default="", type=str)  # full path, with .pth
-    parser.add_argument("--wandb", default="", type=str)  # wandb project name. if "" then don't use wandb
-    parser.add_argument("--proj_dir", default="out", type=str)
-    parser.add_argument("--random_seed", default="-1", type=int)
-
-    parser.add_argument("--data_file", default="", type=str)
-    parser.add_argument("--data_type", default="utf-8", type=str) #binidx / sft
-    parser.add_argument("--vocab_size", default=0, type=int)  # vocab_size = 0 means auto (for char-level LM and .txt data)
-
-    parser.add_argument("--ctx_len", default=1024, type=int)
-    parser.add_argument("--epoch_steps", default=1000, type=int)  # a mini "epoch" has [epoch_steps] steps
-    parser.add_argument("--epoch_count", default=500, type=int)  # train for this many "epochs". will continue afterwards with lr = lr_final
-    parser.add_argument("--epoch_begin", default=0, type=int)  # if you load a model trained for x "epochs", set epoch_begin = x
-    parser.add_argument("--epoch_save", default=5, type=int)  # save the model every [epoch_save] "epochs"
-
-    parser.add_argument("--micro_bsz", default=12, type=int)  # micro batch size (batch size per GPU)
-    parser.add_argument("--n_layer", default=6, type=int)
-    parser.add_argument("--n_embd", default=512, type=int)
-    parser.add_argument("--dim_att", default=0, type=int)
-    parser.add_argument("--dim_ffn", default=0, type=int)
-    parser.add_argument("--pre_ffn", default=0, type=int)  # replace first att layer by ffn (sometimes better)
-    parser.add_argument("--head_qk", default=0, type=int)  # my headQK trick
-    parser.add_argument("--tiny_att_dim", default=0, type=int)  # tiny attention dim
-    parser.add_argument("--tiny_att_layer", default=-999, type=int)  # tiny attention @ which layer
-
-    parser.add_argument("--lr_init", default=6e-4, type=float)  # 6e-4 for L12-D768, 4e-4 for L24-D1024, 3e-4 for L24-D2048
-    parser.add_argument("--lr_final", default=1e-5, type=float)
-    parser.add_argument("--warmup_steps", default=-1, type=int)  # try 50 if you load a model
-    parser.add_argument("--beta1", default=0.9, type=float)
-    parser.add_argument("--beta2", default=0.99, type=float)  # use 0.999 when your model is close to convergence
-    parser.add_argument("--adam_eps", default=1e-8, type=float)
-    parser.add_argument("--grad_cp", default=0, type=int)  # gradient checkpt: saves VRAM, but slower
-    parser.add_argument("--dropout", default=0, type=float) # try 0.01 / 0.02 / 0.05 / 0.1
-    parser.add_argument("--weight_decay", default=0, type=float) # try 0.1 / 0.01 / 0.001
-    parser.add_argument("--weight_decay_final", default=-1, type=float)
-
-    parser.add_argument("--my_pile_version", default=1, type=int)  # my special pile version
-    parser.add_argument("--my_pile_stage", default=0, type=int)  # my special pile mode
-    parser.add_argument("--my_pile_shift", default=-1, type=int)  # my special pile mode - text shift
-    parser.add_argument("--my_pile_edecay", default=0, type=int)
-    parser.add_argument("--layerwise_lr", default=1, type=int)  # layerwise lr for faster convergence (but slower it/s)
-    parser.add_argument("--ds_bucket_mb", default=200, type=int)  # deepspeed bucket size in MB. 200 seems enough
-    # parser.add_argument("--cuda_cleanup", default=0, type=int)  # extra cuda cleanup (sometimes helpful)
-
-    parser.add_argument("--my_sample_len", default=0, type=int)
-    parser.add_argument("--my_ffn_shift", default=1, type=int)
-    parser.add_argument("--my_att_shift", default=1, type=int)
-    parser.add_argument("--head_size_a", default=64, type=int) # can try larger values for larger models
-    parser.add_argument("--head_size_divisor", default=8, type=int)
-    parser.add_argument("--my_pos_emb", default=0, type=int)
-    parser.add_argument("--load_partial", default=0, type=int)
-    parser.add_argument("--magic_prime", default=0, type=int)
-    parser.add_argument("--my_qa_mask", default=0, type=int)
-    parser.add_argument("--my_random_steps", default=0, type=int)
-    parser.add_argument("--my_testing", default='x052', type=str)
-    parser.add_argument("--my_exit", default=99999999, type=int)
-    parser.add_argument("--my_exit_tokens", default=0, type=int)
-
-    parser.add_argument("--peft", default="none", type=str)# lora pissa DiSHA
-    #parser.add_argument("--train_parts", default=["time", "ln"], type=list)##emb , head
-    parser.add_argument("--train_parts", default=["time", "ln"], nargs='*', help="List of parts to train emb head time ln")
-
-    #LORA
-    parser.add_argument("--lora_config", default='{"lora_load":"", "lora_r":8, "lora_alpha":32, "lora_dropout":0.01}', type=json.loads)
+if "deepspeed" in train_config.strategy:
+    import deepspeed
 
 
-    # #LISA
-    # parser.add_argument("--lisa_config", default='{"lisa_r":2, "lisa_k":100}', type=json.loads)
-
-    #PISSA
-    parser.add_argument("--pissa_config", default='{"pissa_load":"", "pissa_init":"", "pissa_r":8, "svd_niter":4}', type=json.loads)
-
-    #Bone
-    parser.add_argument("--disha_config", default='{"mode":"mode", "load":"", "r":64}', type=json.loads)
-
-
-    #quant
-    parser.add_argument("--quant", default="none", type=str)
-
-    #dataset
-    parser.add_argument("--dataload", default="pad", type=str)
-
-    parser.add_argument("--chunk_ctx", default=512, type=int)
-    #fla
-    parser.add_argument("--fla", action="store_true")
-    parser.add_argument("--train_type", default="none", type=str)
-
-    #loss_mask
-    parser.add_argument("--loss_mask", default="none", type=str)### pad qa se
-    parser.add_argument("--mask_id", default='{"mask0":"0", "mask1":"1"}', type=json.loads)
-    parser.add_argument("--data_shuffle", default=1, type=int)
-
-
-    #new optim
-    parser.add_argument("--optim", default="none", type=str)
-
-    #acc_grad_batchs
-    parser.add_argument("--avg_loss", default=0, type=int)
-
-
-    parser.add_argument("--sft_field", default=None, type=str, nargs='+', help='List of fields for SFT')
-    parser.add_argument("--sft_split", default="train", type=str)
-
-
-    parser.add_argument("--op", default="cuda", type=str)
-    parser.add_argument("--fused_kernel", action='store_true', help="Enable rwkv-fla fused kernel")
-
-    parser.add_argument("--lr_schedule", default="cos", type=str)        #['cos', 'wsd']
-
-
-    if pl.__version__[0]=='2':
-        parser.add_argument("--accelerator", default="gpu", type=str)
-        parser.add_argument("--strategy", default="auto", type=str)
-        parser.add_argument("--devices", default=1, type=int)
-        parser.add_argument("--num_nodes", default=1, type=int)
-        parser.add_argument("--precision", default="fp16", type=str)
-        parser.add_argument("--accumulate_grad_batches", default=1, type=int)
-    else:
-        parser = Trainer.add_argparse_args(parser)
-    args = parser.parse_args()
-
-    ########################################################################################################
-
-    import os, warnings, datetime
-    import numpy as np
-    import torch
-
-    if "deepspeed" in args.strategy:
-        import deepspeed
-    # from pytorch_lightning import seed_everything
-
-    if args.random_seed >= 0:
-        print(f"########## WARNING: GLOBAL SEED {args.random_seed} THIS WILL AFFECT MULTIGPU SAMPLING ##########\n" * 3)
-        seed_everything(args.random_seed)
-
+def main():
     np.set_printoptions(precision=4, suppress=True, linewidth=200)
     warnings.filterwarnings("ignore", ".*Consider increasing the value of the `num_workers` argument*")
     warnings.filterwarnings("ignore", ".*The progress bar already tracks a metric with the*")
-    # os.environ["WDS_SHOW_SEED"] = "1"
 
-    #args.vocab_size = get_vocab_size(args)
-    args.my_timestamp = datetime.datetime.today().strftime("%Y-%m-%d-%H-%M-%S")
-    args.enable_checkpointing = False
-    args.replace_sampler_ddp = False
-    args.logger = False
-    args.gradient_clip_val = 1.0
-    args.num_sanity_val_steps = 0
-    args.check_val_every_n_epoch = int(1e20)
-    args.log_every_n_steps = int(1e20)
-      # continue forever
-    args.max_epochs = args.epoch_count
-    if args.dataload =='get':
-        args.max_epochs = -1
-    args.betas = (args.beta1, args.beta2)
-    args.real_bsz = int(args.num_nodes) * int(args.devices) * args.micro_bsz
-    os.environ["RWKV_MY_TESTING"] = args.my_testing
-    os.environ["RWKV_CTXLEN"] = str(args.ctx_len)
-    os.environ["RWKV_HEAD_SIZE_A"] = str(args.head_size_a)
-    ######state tuning
-    os.environ["RWKV_TRAIN_TYPE"]=''
-    if args.train_type=='state':
-        os.environ["RWKV_TRAIN_TYPE"]='state'
-    elif args.train_type=='infctx':
-        os.environ["RWKV_TRAIN_TYPE"]='infctx'
-
-    print(f"########## WKV OP           {args.op}               ##########\n" * 3)
-    print(f"########## FUSED OP    {args.fused_kernel}          ##########\n" * 3)
-    os.environ["WKV"]= args.op
-    os.environ["FUSED_KERNEL"] = '1' if args.fused_kernel else '0'
-
-    if args.dim_att <= 0:
-        args.dim_att = args.n_embd
-    if args.dim_ffn <= 0:
-        args.dim_ffn = int((args.n_embd * 3.5) // 32 * 32) # default = 3.5x emb size
+    file_config.check(); model_config.check(); train_config.check()
+    file_config.show(); model_config.show(); train_config.show()
 
 
-    args.run_name = f"{args.vocab_size} ctx{args.ctx_len} L{args.n_layer} D{args.n_embd}"
-    if not os.path.exists(args.proj_dir):
-        os.makedirs(args.proj_dir)
+    train_config.my_timestamp = datetime.datetime.today().strftime("%Y-%m-%d-%H-%M-%S")
+    train_config.real_bsz = int(train_config.num_nodes) * int(train_config.devices) * train_config.micro_bsz
 
-    if args.my_pile_stage > 0:
-        magic_prime_bak = args.magic_prime
+    args, model = load_peft_model()
 
-        if args.my_pile_shift < 0:
-            args.my_pile_shift = 0
+    trainer = Trainer(
+        accelerator=train_config.accelerator,
+        strategy=train_config.strategy,
+        devices=train_config.devices,
+        num_nodes=train_config.num_nodes,
+        precision=train_config.precision,
+        logger=False,
+        callbacks=[train_callback(train_config)],
+        max_epochs=train_config.epoch_count,
+        check_val_every_n_epoch=train_config.check_val_every_n_epoch,
+        num_sanity_val_steps=train_config.num_sanity_val_steps,
+        log_every_n_steps=train_config.log_every_n_steps,
+        enable_checkpointing=False,
+        accumulate_grad_batches=train_config.accumulate_grad_batches,
+        gradient_clip_val=train_config.gradient_clip_val,
+    )
 
-        if magic_prime_bak > 0:
-            args.magic_prime = magic_prime_bak
-        if args.my_qa_mask == 2:
-            args.epoch_count = 2 * args.magic_prime // 40320
-        else:
-            args.epoch_count = args.magic_prime // 40320
-
-        args.epoch_steps = 40320 // args.real_bsz
-        assert args.epoch_steps * args.real_bsz == 40320
-        # if args.my_pile_stage == 2:
-        #     assert args.lr_final == args.lr_init
-        if args.my_pile_stage >= 2:  # find latest saved model
-            list_p = []
-            for p in os.listdir(args.proj_dir):
-                if p.startswith("rwkv") and p.endswith(".pth"):
-                    p = ((p.split("-"))[1].split("."))[0]
-                    if p != "final":
-                        if p == "init":
-                            p = -1
-                        else:
-                            p = int(p)
-                        list_p += [p]
-            list_p.sort()
-            max_p = list_p[-1]
-            if len(list_p) > 1:
-                args.my_pile_prev_p = list_p[-2]  # in case max_p is corrupted
-            if max_p == -1:
-                args.load_model = f"{args.proj_dir}/rwkv-init.pth"
-            else:
-                args.load_model = f"{args.proj_dir}/rwkv-{max_p}.pth"
-                if args.warmup_steps < 0:
-                    if args.my_pile_stage == 2:
-                        args.warmup_steps = 10
-                    else:
-                        args.warmup_steps = 30
-            args.epoch_begin = max_p + 1
-
-    samples_per_epoch = args.epoch_steps * args.real_bsz
-    tokens_per_epoch = samples_per_epoch * args.ctx_len
-    try:
-        deepspeed_version = deepspeed.__version__
-    except:
-        deepspeed_version = None
-        pass
-#     rank_zero_info(
-#         f"""
-# ############################################################################
-# #
-# # RWKV-5 {args.precision.upper()} on {args.num_nodes}x{args.devices} {args.accelerator.upper()}, bsz {args.num_nodes}x{args.devices}x{args.micro_bsz}={args.real_bsz}, {args.strategy} {'with grad_cp' if args.grad_cp > 0 else ''}
-# #
-# # Data = {args.data_file} ({args.data_type}), ProjDir = {args.proj_dir}
-# #
-# # Epoch = {args.epoch_begin} to {args.epoch_begin + args.epoch_count - 1} (will continue afterwards), save every {args.epoch_save} epoch
-# #
-# # Each "epoch" = {args.epoch_steps} steps, {samples_per_epoch} samples, {tokens_per_epoch} tokens
-# #
-# # Model = {args.n_layer} n_layer, {args.n_embd} n_embd, {args.ctx_len} ctx_len
-# #
-# # Adam = lr {args.lr_init} to {args.lr_final}, warmup {args.warmup_steps} steps, beta {args.betas}, eps {args.adam_eps}
-# #
-# # Found torch {torch.__version__}, recommend 2.4.0 or newer if you use fla
-# # Found deepspeed {deepspeed_version}, recommend 0.7.0 (faster than newer versions)
-# # Found pytorch_lightning {pl.__version__}, recommend 2.4.0 or newer
-# #
-# ############################################################################
-# """
-#     )
-    # rank_zero_info(str(vars(args)) + "\n")
-
-    assert args.data_type in ["utf-8", "utf-16le", "numpy", "binidx", "dummy", "uint16", "sft", 'jsonl']
-
-    if args.lr_final == 0 or args.lr_init == 0:
-        rank_zero_info("\n\nNote: lr_final = 0 or lr_init = 0. Using linear LR schedule instead.\n\n")
-
-    assert args.precision in ["fp32", "tf32", "fp16", "bf16"]
-    os.environ["RWKV_FLOAT_MODE"] = args.precision
-    if args.precision == "fp32":
-        for i in range(10):
-            rank_zero_info("\n\nNote: you are using fp32 (very slow). Try bf16 / tf32 for faster training.\n\n")
-    if args.precision == "fp16":
-        rank_zero_info("\n\nNote: you are using fp16 (might overflow). Try bf16 / tf32 for stable training.\n\n")
-
-    os.environ["RWKV_JIT_ON"] = "0"
-    if "deepspeed_stage_3" in args.strategy:
-        os.environ["RWKV_JIT_ON"] = "0"
-
-    torch.backends.cudnn.benchmark = True
-    torch.backends.cudnn.enabled = True
-    if args.precision == "fp32":
-        torch.backends.cudnn.allow_tf32 = False
-        torch.backends.cuda.matmul.allow_tf32 = False
-    else:
-        torch.backends.cudnn.allow_tf32 = True
-        torch.backends.cuda.matmul.allow_tf32 = True
-
-    if "32" in args.precision:
-        args.precision = 32
-    elif args.precision == "fp16":
-        args.precision = 16
-    else:
-        args.precision = "bf16"
-
-    ########################################################################################################
-
-    from src.rwkvt import train_callback
-    from src.rwkvt.peft.peft_loading import load_peft_model
-
-    args, model = load_peft_model(args)
-
-
-    if pl.__version__[0]=='2':
-        trainer = Trainer(accelerator=args.accelerator,strategy=args.strategy,devices=args.devices,num_nodes=args.num_nodes,precision=args.precision,
-        logger=args.logger,callbacks=[train_callback(args)],max_epochs=args.max_epochs,check_val_every_n_epoch=args.check_val_every_n_epoch,num_sanity_val_steps=args.num_sanity_val_steps,
-        log_every_n_steps=args.log_every_n_steps,enable_checkpointing=args.enable_checkpointing,accumulate_grad_batches=args.accumulate_grad_batches,gradient_clip_val=args.gradient_clip_val)
-    else:
-        trainer = Trainer.from_argparse_args(
-            args,
-            callbacks=[train_callback(args)],
-        )
-
- 
-    train_data = get_data_by_l_version(trainer=trainer, args=args)
-
+    train_data = get_data(trainer)
     trainer.fit(model, train_data)
 
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- drop legacy RWKV5/6 and Lightning 1 support
- replace environment variable checks with global configs
- simplify dataset loader and training entry
- clean up operator to only support RWKV7

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685385fbdfd48320b67e9013bb5e4e17